### PR TITLE
style(prints): switch to warm light stone palette

### DIFF
--- a/src/features/prints/components/PrintCard.vue
+++ b/src/features/prints/components/PrintCard.vue
@@ -2,43 +2,43 @@
     <button @click="$emit('select', print)"
         class="group text-left w-full focus:outline-none">
         <!-- Image Container -->
-        <div class="relative overflow-hidden bg-stone-900 mb-4"
+        <div class="relative overflow-hidden bg-stone-200 mb-4"
             :class="print.orientation === 'portrait' ? 'aspect-[3/4]' : 'aspect-[4/3]'">
 
             <!-- Placeholder shimmer (shown before real images are added) -->
-            <div class="absolute inset-0 bg-gradient-to-br from-stone-800 via-stone-850 to-stone-900">
+            <div class="absolute inset-0 bg-gradient-to-br from-stone-200 via-stone-250 to-stone-300">
                 <div class="absolute inset-0 flex items-center justify-center">
                     <div class="text-center">
-                        <Camera class="w-8 h-8 text-white/10 mx-auto mb-2" />
-                        <span class="text-[10px] tracking-widest uppercase text-white/15">{{ print.title }}</span>
+                        <Camera class="w-8 h-8 text-stone-400/40 mx-auto mb-2" />
+                        <span class="text-[10px] tracking-widest uppercase text-stone-400/50">{{ print.title }}</span>
                     </div>
                 </div>
             </div>
 
             <!-- Hover overlay -->
-            <div class="absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-all duration-500 flex items-center justify-center">
+            <div class="absolute inset-0 bg-stone-900/0 group-hover:bg-stone-900/40 transition-all duration-500 flex items-center justify-center">
                 <div class="opacity-0 group-hover:opacity-100 transition-all duration-500 transform translate-y-2 group-hover:translate-y-0">
-                    <span class="text-xs tracking-[0.3em] uppercase text-white/90 border border-white/30 px-4 py-2">
+                    <span class="text-xs tracking-[0.3em] uppercase text-white/90 border border-white/40 px-4 py-2">
                         View Details
                     </span>
                 </div>
             </div>
 
             <!-- Edition badge -->
-            <div v-if="print.limited" class="absolute top-3 right-3 bg-amber-400/90 text-stone-950 text-[9px] tracking-[0.2em] uppercase px-2 py-1 font-medium">
+            <div v-if="print.limited" class="absolute top-3 right-3 bg-amber-600 text-white text-[9px] tracking-[0.2em] uppercase px-2 py-1 font-medium">
                 Limited Edition
             </div>
         </div>
 
         <!-- Info -->
         <div class="space-y-1">
-            <h3 class="font-serif text-base lg:text-lg text-white/90 group-hover:text-amber-100 transition-colors duration-300">
+            <h3 class="font-serif text-base lg:text-lg text-stone-800 group-hover:text-amber-800 transition-colors duration-300">
                 {{ print.title }}
             </h3>
-            <p class="text-xs tracking-wider text-white/40 uppercase">
+            <p class="text-xs tracking-wider text-stone-400 uppercase">
                 {{ print.location }}
             </p>
-            <p class="text-sm text-amber-400/70 font-light pt-1">
+            <p class="text-sm text-amber-700/70 font-light pt-1">
                 From ${{ print.startingPrice }}
             </p>
         </div>

--- a/src/features/prints/components/PrintDetail.vue
+++ b/src/features/prints/components/PrintDetail.vue
@@ -1,6 +1,6 @@
 <template>
     <Dialog :open="!!print" @update:open="$emit('close')">
-        <DialogContent class="bg-stone-950 border-white/10 max-w-4xl w-full p-0 gap-0 overflow-hidden max-h-[90vh] overflow-y-auto rounded-none sm:rounded-lg">
+        <DialogContent class="bg-stone-50 border-stone-200 max-w-4xl w-full p-0 gap-0 overflow-hidden max-h-[90vh] overflow-y-auto rounded-none sm:rounded-lg">
 
             <!-- Close button -->
             <DialogTitle class="sr-only">{{ print?.title }}</DialogTitle>
@@ -9,10 +9,10 @@
             <div v-if="print" class="flex flex-col lg:flex-row">
 
                 <!-- Image Side -->
-                <div class="lg:w-1/2 bg-stone-900 flex items-center justify-center p-8 lg:p-12 min-h-[300px] lg:min-h-[500px]">
+                <div class="lg:w-1/2 bg-stone-200 flex items-center justify-center p-8 lg:p-12 min-h-[300px] lg:min-h-[500px]">
                     <div class="text-center">
-                        <Camera class="w-12 h-12 text-white/10 mx-auto mb-3" />
-                        <span class="text-[10px] tracking-[0.3em] uppercase text-white/20">{{ print.title }}</span>
+                        <Camera class="w-12 h-12 text-stone-400/30 mx-auto mb-3" />
+                        <span class="text-[10px] tracking-[0.3em] uppercase text-stone-400/50">{{ print.title }}</span>
                     </div>
                 </div>
 
@@ -22,54 +22,54 @@
                     <!-- Header -->
                     <div>
                         <div class="flex items-center gap-2 mb-3">
-                            <span v-if="print.limited" class="text-[9px] tracking-[0.2em] uppercase bg-amber-400/90 text-stone-950 px-2 py-0.5 font-medium">
+                            <span v-if="print.limited" class="text-[9px] tracking-[0.2em] uppercase bg-amber-600 text-white px-2 py-0.5 font-medium">
                                 Limited Edition
                             </span>
-                            <span class="text-[10px] tracking-[0.2em] uppercase text-white/40">{{ print.category }}</span>
+                            <span class="text-[10px] tracking-[0.2em] uppercase text-stone-400">{{ print.category }}</span>
                         </div>
-                        <h2 class="font-serif text-2xl lg:text-3xl text-white/95 leading-tight mb-2">
+                        <h2 class="font-serif text-2xl lg:text-3xl text-stone-800 leading-tight mb-2">
                             {{ print.title }}
                         </h2>
-                        <p class="text-xs tracking-wider text-amber-400/60 uppercase flex items-center gap-1.5">
+                        <p class="text-xs tracking-wider text-amber-700/60 uppercase flex items-center gap-1.5">
                             <MapPin class="w-3 h-3" />
                             {{ print.location }}
                         </p>
                     </div>
 
                     <!-- Description -->
-                    <p class="text-sm text-white/50 font-light leading-relaxed">
+                    <p class="text-sm text-stone-500 font-light leading-relaxed">
                         {{ print.description }}
                     </p>
 
                     <!-- Size Selection -->
                     <div>
-                        <label class="text-[10px] tracking-[0.3em] uppercase text-white/40 block mb-3">Select Size</label>
+                        <label class="text-[10px] tracking-[0.3em] uppercase text-stone-400 block mb-3">Select Size</label>
                         <div class="grid grid-cols-2 gap-2">
                             <button v-for="(size, i) in print.sizes" :key="size.label"
                                 @click="selectedSize = i"
                                 :class="[
                                     'border px-3 py-3 text-left transition-all duration-200',
                                     selectedSize === i
-                                        ? 'border-amber-400/50 bg-amber-400/5'
-                                        : 'border-white/10 hover:border-white/20'
+                                        ? 'border-amber-600/50 bg-amber-50'
+                                        : 'border-stone-200 hover:border-stone-300'
                                 ]">
-                                <span class="block text-sm text-white/80">{{ size.label }}</span>
-                                <span class="block text-xs text-amber-400/70 mt-0.5">${{ size.price }}</span>
+                                <span class="block text-sm text-stone-700">{{ size.label }}</span>
+                                <span class="block text-xs text-amber-700/70 mt-0.5">${{ size.price }}</span>
                             </button>
                         </div>
                     </div>
 
                     <!-- Paper Selection -->
                     <div>
-                        <label class="text-[10px] tracking-[0.3em] uppercase text-white/40 block mb-3">Paper Type</label>
+                        <label class="text-[10px] tracking-[0.3em] uppercase text-stone-400 block mb-3">Paper Type</label>
                         <div class="flex flex-wrap gap-2">
                             <button v-for="paper in print.papers" :key="paper"
                                 @click="selectedPaper = paper"
                                 :class="[
                                     'border px-4 py-2 text-xs tracking-wider transition-all duration-200',
                                     selectedPaper === paper
-                                        ? 'border-amber-400/50 bg-amber-400/5 text-white/80'
-                                        : 'border-white/10 text-white/40 hover:border-white/20 hover:text-white/60'
+                                        ? 'border-amber-600/50 bg-amber-50 text-stone-700'
+                                        : 'border-stone-200 text-stone-400 hover:border-stone-300 hover:text-stone-600'
                                 ]">
                                 {{ paper }}
                             </button>
@@ -77,21 +77,21 @@
                     </div>
 
                     <!-- Price & Purchase -->
-                    <div class="pt-4 border-t border-white/5">
+                    <div class="pt-4 border-t border-stone-200">
                         <div class="flex items-end justify-between mb-6">
                             <div>
-                                <span class="text-[10px] tracking-[0.2em] uppercase text-white/30 block mb-1">Total</span>
-                                <span class="font-serif text-3xl text-white/95">${{ currentPrice }}</span>
-                                <span class="text-xs text-white/30 ml-1">AUD</span>
+                                <span class="text-[10px] tracking-[0.2em] uppercase text-stone-400 block mb-1">Total</span>
+                                <span class="font-serif text-3xl text-stone-800">${{ currentPrice }}</span>
+                                <span class="text-xs text-stone-400 ml-1">AUD</span>
                             </div>
                         </div>
 
                         <button @click="handlePurchase"
-                            class="w-full py-4 bg-amber-400/90 hover:bg-amber-400 text-stone-950 text-xs tracking-[0.25em] uppercase font-medium transition-all duration-300 hover:shadow-lg hover:shadow-amber-400/20">
+                            class="w-full py-4 bg-stone-800 hover:bg-stone-900 text-stone-50 text-xs tracking-[0.25em] uppercase font-medium transition-all duration-300 hover:shadow-lg">
                             Purchase Print
                         </button>
 
-                        <p class="text-[10px] text-white/25 text-center mt-3 tracking-wider">
+                        <p class="text-[10px] text-stone-400 text-center mt-3 tracking-wider">
                             Printed & shipped by Printful. Secure checkout via Stripe.
                         </p>
                     </div>

--- a/src/features/prints/components/PrintsAbout.vue
+++ b/src/features/prints/components/PrintsAbout.vue
@@ -4,38 +4,38 @@
             <div class="grid lg:grid-cols-2 gap-16 items-center">
 
                 <!-- Image placeholder -->
-                <div class="relative aspect-[4/5] bg-stone-900 overflow-hidden">
+                <div class="relative aspect-[4/5] bg-stone-200 overflow-hidden">
                     <div class="absolute inset-0 flex items-center justify-center">
                         <div class="text-center">
-                            <User class="w-10 h-10 text-white/10 mx-auto mb-2" />
-                            <span class="text-[10px] tracking-widest uppercase text-white/15">Portrait</span>
+                            <User class="w-10 h-10 text-stone-400/30 mx-auto mb-2" />
+                            <span class="text-[10px] tracking-widest uppercase text-stone-400/40">Portrait</span>
                         </div>
                     </div>
                     <!-- Decorative corner frame -->
-                    <div class="absolute top-4 left-4 w-8 h-8 border-l border-t border-amber-400/30" />
-                    <div class="absolute bottom-4 right-4 w-8 h-8 border-r border-b border-amber-400/30" />
+                    <div class="absolute top-4 left-4 w-8 h-8 border-l border-t border-amber-700/25" />
+                    <div class="absolute bottom-4 right-4 w-8 h-8 border-r border-b border-amber-700/25" />
                 </div>
 
                 <!-- Text -->
                 <div class="space-y-6">
                     <div>
-                        <span class="text-[10px] tracking-[0.5em] uppercase text-amber-400/60 font-light block mb-4">The Photographer</span>
-                        <h2 class="font-serif text-3xl lg:text-4xl text-white/90 leading-tight">
+                        <span class="text-[10px] tracking-[0.5em] uppercase text-amber-700/50 font-light block mb-4">The Photographer</span>
+                        <h2 class="font-serif text-3xl lg:text-4xl text-stone-800 leading-tight">
                             Mason<br />
-                            <span class="italic font-light text-amber-100/70">Bartholomai</span>
+                            <span class="italic font-light text-stone-500">Bartholomai</span>
                         </h2>
                     </div>
 
-                    <div class="h-px w-16 bg-amber-400/30" />
+                    <div class="h-px w-16 bg-amber-700/25" />
 
-                    <p class="text-sm text-white/50 font-light leading-relaxed">
+                    <p class="text-sm text-stone-500 font-light leading-relaxed">
                         Based in Australia, I spend my time chasing light across landscapes
                         that most people only see in passing. From the red dust of the outback
                         to the misty canopies of ancient rainforests, my work captures the quiet
                         moments that make the natural world extraordinary.
                     </p>
 
-                    <p class="text-sm text-white/50 font-light leading-relaxed">
+                    <p class="text-sm text-stone-500 font-light leading-relaxed">
                         Every print in this collection represents hours of patience, planning,
                         and a deep respect for the places I photograph. I believe great landscape
                         photography isn't about finding new places — it's about seeing familiar
@@ -44,18 +44,18 @@
 
                     <div class="pt-4 flex items-center gap-6">
                         <div class="text-center">
-                            <span class="block font-serif text-2xl text-white/80">50+</span>
-                            <span class="text-[9px] tracking-[0.2em] uppercase text-white/30">Locations</span>
+                            <span class="block font-serif text-2xl text-stone-700">50+</span>
+                            <span class="text-[9px] tracking-[0.2em] uppercase text-stone-400">Locations</span>
                         </div>
-                        <div class="h-8 w-px bg-white/10" />
+                        <div class="h-8 w-px bg-stone-300" />
                         <div class="text-center">
-                            <span class="block font-serif text-2xl text-white/80">5</span>
-                            <span class="text-[9px] tracking-[0.2em] uppercase text-white/30">Years</span>
+                            <span class="block font-serif text-2xl text-stone-700">5</span>
+                            <span class="text-[9px] tracking-[0.2em] uppercase text-stone-400">Years</span>
                         </div>
-                        <div class="h-8 w-px bg-white/10" />
+                        <div class="h-8 w-px bg-stone-300" />
                         <div class="text-center">
-                            <span class="block font-serif text-2xl text-white/80">AUS</span>
-                            <span class="text-[9px] tracking-[0.2em] uppercase text-white/30">Based</span>
+                            <span class="block font-serif text-2xl text-stone-700">AUS</span>
+                            <span class="text-[9px] tracking-[0.2em] uppercase text-stone-400">Based</span>
                         </div>
                     </div>
                 </div>

--- a/src/features/prints/components/PrintsFooter.vue
+++ b/src/features/prints/components/PrintsFooter.vue
@@ -1,33 +1,33 @@
 <template>
-    <footer class="relative border-t border-white/5">
+    <footer class="relative border-t border-stone-300/50">
         <div class="max-w-5xl mx-auto px-6 lg:px-8 py-12">
             <div class="flex flex-col md:flex-row justify-between items-center gap-8">
 
                 <!-- Brand -->
                 <div class="text-center md:text-left">
-                    <span class="font-serif text-lg tracking-[0.15em] text-white/80 block uppercase">Mason Bartholomai</span>
-                    <span class="text-[10px] tracking-[0.3em] text-amber-400/50 uppercase">Landscape Photography</span>
+                    <span class="font-serif text-lg tracking-[0.15em] text-stone-700 block uppercase">Mason Bartholomai</span>
+                    <span class="text-[10px] tracking-[0.3em] text-amber-700/50 uppercase">Landscape Photography</span>
                 </div>
 
                 <!-- Links -->
                 <div class="flex items-center gap-8">
-                    <a href="/" class="text-[11px] tracking-wider uppercase text-white/30 hover:text-white/60 transition-colors duration-300">
+                    <a href="/" class="text-[11px] tracking-wider uppercase text-stone-400 hover:text-stone-600 transition-colors duration-300">
                         MXN.au
                     </a>
-                    <button @click="scrollToTop" class="text-[11px] tracking-wider uppercase text-white/30 hover:text-white/60 transition-colors duration-300">
+                    <button @click="scrollToTop" class="text-[11px] tracking-wider uppercase text-stone-400 hover:text-stone-600 transition-colors duration-300">
                         Back to Top
                     </button>
                 </div>
             </div>
 
             <!-- Bottom -->
-            <div class="mt-8 pt-6 border-t border-white/5 flex flex-col sm:flex-row items-center justify-between gap-4">
-                <p class="text-[10px] tracking-wider text-white/20">
+            <div class="mt-8 pt-6 border-t border-stone-300/30 flex flex-col sm:flex-row items-center justify-between gap-4">
+                <p class="text-[10px] tracking-wider text-stone-400">
                     &copy; {{ new Date().getFullYear() }} Mason Bartholomai. All rights reserved.
                 </p>
-                <div class="flex items-center gap-4 text-[10px] tracking-wider text-white/20">
+                <div class="flex items-center gap-4 text-[10px] tracking-wider text-stone-400">
                     <span>Powered by Printful</span>
-                    <span class="text-white/10">&middot;</span>
+                    <span class="text-stone-300">&middot;</span>
                     <span>Payments by Stripe</span>
                 </div>
             </div>

--- a/src/features/prints/components/PrintsGallery.vue
+++ b/src/features/prints/components/PrintsGallery.vue
@@ -4,9 +4,9 @@
 
             <!-- Section Header -->
             <div class="text-center mb-16 lg:mb-20">
-                <span class="text-[10px] tracking-[0.5em] uppercase text-amber-400/60 font-light block mb-4">The Collection</span>
-                <h2 class="font-serif text-3xl lg:text-5xl text-white/90 mb-4">Selected Works</h2>
-                <p class="text-sm text-white/40 font-light max-w-md mx-auto leading-relaxed">
+                <span class="text-[10px] tracking-[0.5em] uppercase text-amber-700/50 font-light block mb-4">The Collection</span>
+                <h2 class="font-serif text-3xl lg:text-5xl text-stone-800 mb-4">Selected Works</h2>
+                <p class="text-sm text-stone-500 font-light max-w-md mx-auto leading-relaxed">
                     Each photograph is available as a museum-quality print, produced on demand with archival inks and premium papers.
                 </p>
             </div>
@@ -18,8 +18,8 @@
                     :class="[
                         'text-[11px] tracking-[0.2em] uppercase px-4 py-2 border transition-all duration-300',
                         activeTag === tag
-                            ? 'border-amber-400/50 text-amber-200 bg-amber-400/5'
-                            : 'border-white/10 text-white/40 hover:text-white/60 hover:border-white/20'
+                            ? 'border-amber-700/40 text-amber-800 bg-amber-50'
+                            : 'border-stone-300 text-stone-400 hover:text-stone-600 hover:border-stone-400'
                     ]">
                     {{ tag }}
                 </button>
@@ -34,8 +34,8 @@
 
             <!-- Empty state -->
             <div v-if="filteredPrints.length === 0" class="text-center py-20">
-                <Camera class="w-10 h-10 text-white/10 mx-auto mb-4" />
-                <p class="text-white/30 text-sm font-light">No prints in this category yet.</p>
+                <Camera class="w-10 h-10 text-stone-300 mx-auto mb-4" />
+                <p class="text-stone-400 text-sm font-light">No prints in this category yet.</p>
             </div>
         </div>
     </section>

--- a/src/features/prints/components/PrintsHeader.vue
+++ b/src/features/prints/components/PrintsHeader.vue
@@ -2,17 +2,17 @@
     <header :class="[
         'fixed top-0 left-0 w-full z-50 transition-all duration-500',
         isHidden ? '-translate-y-full' : 'translate-y-0',
-        isScrolled ? 'bg-stone-950/80 backdrop-blur-xl border-b border-white/5' : 'bg-transparent'
+        isScrolled ? 'bg-stone-100/90 backdrop-blur-xl border-b border-stone-300/50 shadow-sm' : 'bg-transparent'
     ]">
         <div class="max-w-7xl mx-auto px-6 lg:px-8">
             <div class="flex justify-between items-center h-16 lg:h-20">
 
                 <!-- Brand -->
                 <a href="/prints" class="group flex flex-col">
-                    <span class="font-serif text-lg lg:text-xl tracking-[0.2em] text-white/90 group-hover:text-white transition-colors duration-300 uppercase">
+                    <span class="font-serif text-lg lg:text-xl tracking-[0.2em] text-stone-800 group-hover:text-stone-950 transition-colors duration-300 uppercase">
                         Mason Bartholomai
                     </span>
-                    <span class="text-[10px] lg:text-xs tracking-[0.35em] text-amber-400/70 uppercase font-light">
+                    <span class="text-[10px] lg:text-xs tracking-[0.35em] text-amber-700/60 uppercase font-light">
                         Photography
                     </span>
                 </a>
@@ -20,7 +20,7 @@
                 <!-- Desktop Nav -->
                 <nav class="hidden md:flex items-center gap-8">
                     <button v-for="link in links" :key="link.id" @click="scrollToSection(link.id)"
-                        class="text-xs tracking-[0.2em] uppercase text-white/60 hover:text-white transition-colors duration-300 font-light">
+                        class="text-xs tracking-[0.2em] uppercase text-stone-500 hover:text-stone-800 transition-colors duration-300 font-light">
                         {{ link.label }}
                     </button>
                 </nav>
@@ -29,18 +29,18 @@
                 <Drawer>
                     <DrawerTrigger as-child>
                         <button class="flex md:hidden items-center justify-center">
-                            <Menu class="w-5 h-5 text-white/70 hover:text-white transition-colors" />
+                            <Menu class="w-5 h-5 text-stone-500 hover:text-stone-800 transition-colors" />
                         </button>
                     </DrawerTrigger>
 
-                    <DrawerContent class="bg-stone-950/95 backdrop-blur-xl border-t border-amber-400/10">
+                    <DrawerContent class="bg-stone-100/95 backdrop-blur-xl border-t border-stone-300/50">
                         <DrawerTitle class="sr-only">Navigation Menu</DrawerTitle>
                         <DrawerDescription class="sr-only">Navigate the prints shop.</DrawerDescription>
 
                         <nav class="flex flex-col items-center gap-4 py-8 px-6">
                             <DrawerClose v-for="link in links" :key="link.id" as-child>
                                 <button @click="handleDrawerClick(link.id)"
-                                    class="text-sm tracking-[0.25em] uppercase text-white/70 hover:text-amber-400 transition-colors duration-300 py-2">
+                                    class="text-sm tracking-[0.25em] uppercase text-stone-500 hover:text-amber-700 transition-colors duration-300 py-2">
                                     {{ link.label }}
                                 </button>
                             </DrawerClose>

--- a/src/features/prints/components/PrintsHero.vue
+++ b/src/features/prints/components/PrintsHero.vue
@@ -1,36 +1,36 @@
 <template>
     <section class="relative min-h-screen flex items-center justify-center overflow-hidden">
-        <!-- Background Image Placeholder (blurred, dark overlay) -->
-        <div class="absolute inset-0 bg-stone-950">
-            <div class="absolute inset-0 bg-gradient-to-b from-stone-900/50 via-stone-950/70 to-stone-950" />
-            <!-- Subtle ambient glow -->
-            <div class="absolute top-1/4 left-1/2 -translate-x-1/2 w-[600px] h-[400px] bg-amber-500/5 rounded-full blur-[120px]" />
+        <!-- Background -->
+        <div class="absolute inset-0 bg-stone-200">
+            <div class="absolute inset-0 bg-gradient-to-b from-stone-100/50 via-stone-200/70 to-stone-100" />
+            <!-- Subtle warm glow -->
+            <div class="absolute top-1/4 left-1/2 -translate-x-1/2 w-[600px] h-[400px] bg-amber-200/20 rounded-full blur-[120px]" />
         </div>
 
         <!-- Content -->
         <div class="relative z-10 text-center px-6 max-w-4xl mx-auto">
             <!-- Decorative line -->
             <div class="flex items-center justify-center gap-4 mb-8">
-                <div class="h-px w-12 bg-gradient-to-r from-transparent to-amber-400/50" />
-                <span class="text-[10px] tracking-[0.5em] uppercase text-amber-400/70 font-light">Fine Art Prints</span>
-                <div class="h-px w-12 bg-gradient-to-l from-transparent to-amber-400/50" />
+                <div class="h-px w-12 bg-gradient-to-r from-transparent to-amber-700/40" />
+                <span class="text-[10px] tracking-[0.5em] uppercase text-amber-700/60 font-light">Fine Art Prints</span>
+                <div class="h-px w-12 bg-gradient-to-l from-transparent to-amber-700/40" />
             </div>
 
             <!-- Title -->
-            <h1 class="font-serif text-5xl sm:text-6xl lg:text-8xl text-white/95 leading-[0.9] mb-6 tracking-tight">
+            <h1 class="font-serif text-5xl sm:text-6xl lg:text-8xl text-stone-800 leading-[0.9] mb-6 tracking-tight">
                 Captured
-                <span class="block mt-2 italic font-light text-amber-100/80">Landscapes</span>
+                <span class="block mt-2 italic font-light text-stone-500">Landscapes</span>
             </h1>
 
             <!-- Subtitle -->
-            <p class="text-base sm:text-lg text-white/50 font-light max-w-xl mx-auto leading-relaxed mb-10 tracking-wide">
+            <p class="text-base sm:text-lg text-stone-500 font-light max-w-xl mx-auto leading-relaxed mb-10 tracking-wide">
                 Museum-quality prints of Australia's most breathtaking landscapes.
                 Each piece is printed on archival paper, ready to transform your space.
             </p>
 
             <!-- CTA -->
             <button @click="scrollToCollection"
-                class="group inline-flex items-center gap-3 px-8 py-3.5 border border-amber-400/30 hover:border-amber-400/60 rounded-none text-sm tracking-[0.2em] uppercase text-amber-100/80 hover:text-amber-100 transition-all duration-500 hover:bg-amber-400/5">
+                class="group inline-flex items-center gap-3 px-8 py-3.5 border border-stone-400/50 hover:border-stone-500 rounded-none text-sm tracking-[0.2em] uppercase text-stone-600 hover:text-stone-800 transition-all duration-500 hover:bg-stone-300/20">
                 <span>View Collection</span>
                 <ArrowDown class="w-4 h-4 group-hover:translate-y-1 transition-transform duration-300" />
             </button>
@@ -38,7 +38,7 @@
 
         <!-- Scroll Indicator -->
         <div class="absolute bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-2 animate-pulse">
-            <div class="w-px h-12 bg-gradient-to-b from-transparent to-white/20" />
+            <div class="w-px h-12 bg-gradient-to-b from-transparent to-stone-400/30" />
         </div>
     </section>
 </template>

--- a/src/features/prints/components/PrintsProcess.vue
+++ b/src/features/prints/components/PrintsProcess.vue
@@ -1,15 +1,15 @@
 <template>
     <section id="process" class="relative py-24 lg:py-32">
         <!-- Subtle divider -->
-        <div class="absolute top-0 left-1/2 -translate-x-1/2 w-3/4 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
+        <div class="absolute top-0 left-1/2 -translate-x-1/2 w-3/4 h-px bg-gradient-to-r from-transparent via-stone-300/60 to-transparent" />
 
         <div class="max-w-5xl mx-auto px-6 lg:px-8">
 
             <!-- Section Header -->
             <div class="text-center mb-16 lg:mb-20">
-                <span class="text-[10px] tracking-[0.5em] uppercase text-amber-400/60 font-light block mb-4">Quality Assured</span>
-                <h2 class="font-serif text-3xl lg:text-5xl text-white/90 mb-4">The Process</h2>
-                <p class="text-sm text-white/40 font-light max-w-lg mx-auto leading-relaxed">
+                <span class="text-[10px] tracking-[0.5em] uppercase text-amber-700/50 font-light block mb-4">Quality Assured</span>
+                <h2 class="font-serif text-3xl lg:text-5xl text-stone-800 mb-4">The Process</h2>
+                <p class="text-sm text-stone-500 font-light max-w-lg mx-auto leading-relaxed">
                     From capture to your wall — every step is handled with care.
                 </p>
             </div>
@@ -17,11 +17,11 @@
             <!-- Steps -->
             <div class="grid sm:grid-cols-3 gap-8 lg:gap-12">
                 <div v-for="step in steps" :key="step.title" class="text-center group">
-                    <div class="w-16 h-16 mx-auto mb-6 border border-white/10 group-hover:border-amber-400/30 flex items-center justify-center transition-all duration-500">
-                        <component :is="step.icon" class="w-6 h-6 text-white/30 group-hover:text-amber-400/70 transition-colors duration-500" />
+                    <div class="w-16 h-16 mx-auto mb-6 border border-stone-300 group-hover:border-amber-600/40 flex items-center justify-center transition-all duration-500">
+                        <component :is="step.icon" class="w-6 h-6 text-stone-400 group-hover:text-amber-700 transition-colors duration-500" />
                     </div>
-                    <h3 class="font-serif text-lg text-white/80 mb-2">{{ step.title }}</h3>
-                    <p class="text-xs text-white/40 font-light leading-relaxed max-w-xs mx-auto">
+                    <h3 class="font-serif text-lg text-stone-700 mb-2">{{ step.title }}</h3>
+                    <p class="text-xs text-stone-400 font-light leading-relaxed max-w-xs mx-auto">
                         {{ step.description }}
                     </p>
                 </div>
@@ -29,8 +29,8 @@
 
             <!-- Trust badges -->
             <div class="mt-20 flex flex-wrap justify-center gap-8 lg:gap-12">
-                <div v-for="badge in badges" :key="badge" class="flex items-center gap-2 text-white/25">
-                    <Check class="w-3.5 h-3.5 text-amber-400/50" />
+                <div v-for="badge in badges" :key="badge" class="flex items-center gap-2 text-stone-400">
+                    <Check class="w-3.5 h-3.5 text-amber-600/60" />
                     <span class="text-[11px] tracking-wider uppercase">{{ badge }}</span>
                 </div>
             </div>

--- a/src/features/prints/views/PrintsHome.vue
+++ b/src/features/prints/views/PrintsHome.vue
@@ -1,11 +1,11 @@
 <template>
-    <div class="prints-page bg-stone-950 text-white min-h-screen">
+    <div class="prints-page bg-stone-100 text-stone-900 min-h-screen">
         <PrintsHeader />
         <PrintsHero />
 
         <!-- Divider -->
         <div class="w-full flex justify-center py-2">
-            <div class="h-px w-2/3 bg-gradient-to-r from-transparent via-amber-400/15 to-transparent" />
+            <div class="h-px w-2/3 bg-gradient-to-r from-transparent via-stone-400/30 to-transparent" />
         </div>
 
         <PrintsGallery @select="selectedPrint = $event" />


### PR DESCRIPTION
Convert the entire prints shop from dark (stone-950) to a warm light stone aesthetic (stone-100/200 backgrounds, stone-700/800 text, amber accents). Creates a clean, editorial feel that stands apart from the dark main site — closer to a gallery or photography portfolio.

https://claude.ai/code/session_01LpRQnJ5baaCGcpQ3QckAL3