### PR TITLE
Add robust upload error handling, fatal error modal, and stable room section IDs

### DIFF
--- a/src/features/everhomes/components/ChecklistSection.vue
+++ b/src/features/everhomes/components/ChecklistSection.vue
@@ -182,10 +182,13 @@
             >
               <AlertTriangle class="w-4 h-4 text-rose-300" />
               <span class="text-[9px] font-bold text-rose-200 text-center leading-tight">
-                {{ photo.retryNote ?? 'Upload failed' }}
+                {{ photo.retryNote ?? photo.errorMessage ?? 'Upload failed' }}
+              </span>
+              <span v-if="photo.errorCode" class="text-[9px] text-rose-100/80 text-center leading-tight">
+                {{ photo.errorCode }}
               </span>
               <button
-                v-if="!photo.retryNote"
+                v-if="!photo.retryNote && photo.retryable !== false"
                 @click.stop="reportState.retryPhoto(section.id, pIdx)"
                 class="text-[10px] font-black text-white bg-rose-500 rounded-lg px-2 py-1 hover:bg-rose-400 transition-colors"
               >

--- a/src/features/everhomes/components/ErrorLogModal.vue
+++ b/src/features/everhomes/components/ErrorLogModal.vue
@@ -1,0 +1,81 @@
+<!-- src/features/everhomes/components/ErrorLogModal.vue -->
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition duration-200 ease-out"
+      leave-active-class="transition duration-150 ease-in"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="open"
+        class="fixed inset-0 z-[80] flex items-center justify-center px-4 py-6"
+      >
+        <div class="absolute inset-0 bg-black/75 backdrop-blur-sm" @click="emit('close')" />
+
+        <div class="relative z-10 w-full max-w-xl bg-slate-900 border border-slate-700 rounded-2xl shadow-2xl overflow-hidden">
+          <div class="px-5 py-4 border-b border-slate-700 bg-gradient-to-r from-rose-900/60 to-orange-900/40">
+            <h3 class="text-white font-black text-base tracking-tight">
+              Oops, something went wrong
+            </h3>
+            <p class="text-rose-200/90 text-xs mt-1 font-medium leading-relaxed">
+              Please screenshot this page (and all text below) and send it to Mason.
+            </p>
+          </div>
+
+          <div class="px-5 py-4 space-y-3">
+            <p class="text-slate-300 text-sm font-semibold">
+              {{ message }}
+            </p>
+
+            <div class="rounded-xl border border-slate-700 bg-slate-950/80">
+              <div class="px-3 py-2 border-b border-slate-800">
+                <p class="text-[0.7rem] uppercase tracking-widest font-black text-slate-400">
+                  Error logs
+                </p>
+              </div>
+              <pre class="max-h-64 overflow-auto text-[0.72rem] leading-relaxed text-rose-200 p-3 whitespace-pre-wrap break-words">{{ logs || 'No logs captured.' }}</pre>
+            </div>
+
+            <div class="flex items-center justify-end gap-2 pt-1">
+              <button
+                @click="copyLogs"
+                class="px-3 py-2 rounded-xl border border-slate-700 text-slate-300 hover:text-white hover:border-slate-500 text-xs font-bold transition-colors"
+              >
+                Copy logs
+              </button>
+              <button
+                @click="emit('close')"
+                class="px-3 py-2 rounded-xl bg-rose-600 hover:bg-rose-500 text-white text-xs font-black transition-colors"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup>
+const props = defineProps({
+  open: { type: Boolean, default: false },
+  message: { type: String, default: '' },
+  logs: { type: String, default: '' },
+})
+
+const emit = defineEmits(['close'])
+
+async function copyLogs() {
+  const text = [props.message, '', props.logs].filter(Boolean).join('\n')
+  if (!text) return
+  try {
+    await navigator.clipboard.writeText(text)
+  } catch {
+    // no-op: clipboard may be unavailable in restricted contexts
+  }
+}
+</script>

--- a/src/features/everhomes/components/ReportSetup.vue
+++ b/src/features/everhomes/components/ReportSetup.vue
@@ -188,7 +188,11 @@
               </button>
               <!-- OOA toggle -->
               <button
-                @click="reportState.updateRoom(room.id, { isOOA: !room.isOOA, hasEnsuite: false })"
+                @click="reportState.updateRoom(room.id, {
+                  isOOA: !room.isOOA,
+                  key: room.isOOA ? 'bedroom' : 'ooa',
+                  hasEnsuite: false,
+                })"
                 class="shrink-0 flex items-center gap-1.5 px-3 py-2.5 rounded-xl border text-xs font-bold transition-all duration-150"
                 :class="room.isOOA
                   ? 'bg-rose-500 border-rose-500 text-white shadow-sm'

--- a/src/features/everhomes/composables/useReportState.js
+++ b/src/features/everhomes/composables/useReportState.js
@@ -40,6 +40,14 @@ const CHECKED_STATUSES = new Set(['ok', 'attention', 'issue', 'na'])
 // Item types that are inputs — they go into section.inputs, not section.items
 const INPUT_TYPES = new Set(['text', 'number', 'multiline', 'yesno'])
 
+// Firebase Storage error codes that are generally worth retrying automatically
+const RETRYABLE_STORAGE_CODES = new Set([
+    'storage/retry-limit-exceeded',
+    'storage/unknown',
+    'storage/quota-exceeded',
+    'storage/canceled',
+])
+
 // ─── Composable ───────────────────────────────────────────────────────────────
 
 export function useReportState(schema) {
@@ -72,9 +80,29 @@ export function useReportState(schema) {
     // Tracked continuously — components can read isOnline and show a banner
     // rather than only discovering offline state at submit time.
     const isOnline = ref(navigator.onLine)
+    const fatalError = reactive({
+        open: false,
+        title: 'Upload Error',
+        message: '',
+        logs: '',
+    })
 
     function handleOnline()  { isOnline.value = true }
     function handleOffline() { isOnline.value = false }
+
+    function openFatalError(payload = {}) {
+        fatalError.open = true
+        fatalError.title = payload.title ?? 'Upload Error'
+        fatalError.message = payload.message ?? 'An unexpected error occurred.'
+        fatalError.logs = payload.logs ?? ''
+    }
+
+    function closeFatalError() {
+        fatalError.open = false
+        fatalError.title = 'Upload Error'
+        fatalError.message = ''
+        fatalError.logs = ''
+    }
 
     onMounted(() => {
         window.addEventListener('online',  handleOnline)
@@ -194,6 +222,13 @@ export function useReportState(schema) {
         }
     }
 
+    function migrateLegacySectionData(nextId, legacyIds = []) {
+        if (store.checklistData[nextId]) return
+        const legacyId = legacyIds.find((id) => id && store.checklistData[id])
+        if (!legacyId) return
+        store.checklistData[nextId] = store.checklistData[legacyId]
+    }
+
     // ── Section building — toggle mode (handover) ─────────────────────────────
     function buildToggleSections() {
         const sections = []
@@ -255,19 +290,23 @@ export function useReportState(schema) {
             if (!poolEntry) continue
 
             instanceCount[room.key] = (instanceCount[room.key] ?? 0) + 1
-            const count    = instanceCount[room.key]
-            const sectionId = `${room.key}_${count}`
-            const label    = room.label || `${poolEntry.label} ${count}`
+            const count = instanceCount[room.key]
+            const sectionId = `room_${room.id}`
+            const legacySectionId = `${room.key}_${count}`
+            const label = room.label || `${poolEntry.label} ${count}`
 
             rooms.push({ id: sectionId, key: room.key, label, isOOA: room.isOOA ?? false, isEnsuite: false, meta: poolEntry })
+            migrateLegacySectionData(sectionId, [legacySectionId])
             seedSectionData(sectionId, poolEntry.itemsKey ?? room.key)
 
             // Auto-create ensuite if this room has one
             if (room.hasEnsuite) {
                 const ensuitePoolEntry = poolByKey['ensuite']
-                const ensuiteId    = `ensuite_${count}`
+                const ensuiteId    = `ensuite_${room.id}`
+                const legacyEnsuiteId = `ensuite_${count}`
                 const ensuiteLabel = `${label} — Ensuite`
                 rooms.push({ id: ensuiteId, key: 'ensuite', label: ensuiteLabel, isOOA: false, isEnsuite: true, meta: ensuitePoolEntry })
+                migrateLegacySectionData(ensuiteId, [legacyEnsuiteId])
                 seedSectionData(ensuiteId, 'ensuite')
             }
         }
@@ -567,7 +606,43 @@ export function useReportState(schema) {
     const MAX_UPLOAD_ATTEMPTS  = 3
     const UPLOAD_TIMEOUT_MS    = 30_000
 
-    async function uploadPhotoToStorage(file, pathPrefix) {
+    function classifyUploadError(err, context = {}) {
+        const code = err?.code ?? 'unknown'
+        const message = err?.message ?? 'Unknown upload error'
+        const retryable = RETRYABLE_STORAGE_CODES.has(code) || /timeout/i.test(message)
+
+        const info = {
+            timestamp: new Date().toISOString(),
+            code,
+            message,
+            retryable,
+            path: context.path ?? '',
+            pathPrefix: context.pathPrefix ?? '',
+            sectionId: context.sectionId ?? '',
+            slotKey: context.slotKey ?? '',
+            fileName: context.fileName ?? '',
+            fileType: context.fileType ?? '',
+            fileSize: context.fileSize ?? 0,
+        }
+
+        info.logText = [
+            `timestamp: ${info.timestamp}`,
+            `code: ${info.code}`,
+            `message: ${info.message}`,
+            `retryable: ${String(info.retryable)}`,
+            `path: ${info.path}`,
+            `pathPrefix: ${info.pathPrefix}`,
+            `sectionId: ${info.sectionId}`,
+            `slotKey: ${info.slotKey}`,
+            `fileName: ${info.fileName}`,
+            `fileType: ${info.fileType}`,
+            `fileSize: ${info.fileSize}`,
+        ].join('\n')
+
+        return info
+    }
+
+    async function uploadPhotoToStorage(file, pathPrefix, context = {}) {
         const reportId = store.setup.reportId
         if (!reportId) throw new Error('No report ID — start the report first')
 
@@ -590,7 +665,14 @@ export function useReportState(schema) {
                 const url = await getDownloadURL(ref)
                 return { url, storagePath: path }
             } catch (err) {
-                lastError = err
+                lastError = classifyUploadError(err, {
+                    ...context,
+                    path,
+                    pathPrefix,
+                    fileName: file?.name ?? '',
+                    fileType: file?.type ?? '',
+                    fileSize: file?.size ?? 0,
+                })
                 if (attempt < MAX_UPLOAD_ATTEMPTS) {
                     await new Promise((r) => setTimeout(r, 1000 * attempt))
                 }
@@ -601,7 +683,26 @@ export function useReportState(schema) {
 
     async function addPhoto(sectionId, file) {
         const entry = store.checklistData[sectionId]
-        if (!entry) return
+        if (!entry) {
+            const missing = {
+                code: 'section/not-found',
+                message: `Photo upload section not found: ${sectionId}`,
+                retryable: false,
+                logText: [
+                    `timestamp: ${new Date().toISOString()}`,
+                    `code: section/not-found`,
+                    `message: Photo upload section not found: ${sectionId}`,
+                    `sectionId: ${sectionId}`,
+                    `availableSectionIds: ${Object.keys(store.checklistData).join(', ')}`,
+                ].join('\n'),
+            }
+            openFatalError({
+                title: 'Upload Error',
+                message: 'Oops, something went wrong while uploading this photo.',
+                logs: missing.logText,
+            })
+            return
+        }
 
         const previewUrl = URL.createObjectURL(file)
         const photo = reactive({
@@ -610,6 +711,9 @@ export function useReportState(schema) {
             url:          null,
             storagePath:  null,
             caption:      '',
+            errorCode:    null,
+            errorMessage: '',
+            retryable:    true,
             uploadStatus: 'uploading',
         })
 
@@ -618,15 +722,31 @@ export function useReportState(schema) {
 
         // Return the reactive photo entry immediately so the caller (PhotoPanel)
         // can set the caption before the upload completes.
-        uploadPhotoToStorage(file, `photos/${sectionId}`)
+        uploadPhotoToStorage(file, `photos/${sectionId}`, { sectionId })
             .then(({ url, storagePath }) => {
                 photo.url          = url
                 photo.thumbUrl     = url
                 photo.storagePath  = storagePath
+                photo.errorCode    = null
+                photo.errorMessage = ''
+                photo.retryable    = true
                 photo.uploadStatus = 'done'
             })
-            .catch(() => {
+            .catch((errInfo) => {
+                photo.errorCode    = errInfo?.code ?? 'unknown'
+                photo.errorMessage = errInfo?.message ?? 'Upload failed'
+                photo.retryable    = errInfo?.retryable !== false
                 photo.uploadStatus = 'failed'
+                if (import.meta.env.DEV) {
+                    console.warn('[everhomes] section photo upload failed', errInfo)
+                }
+                if (photo.retryable === false) {
+                    openFatalError({
+                        title: 'Upload Error',
+                        message: 'Oops, something went wrong while uploading this photo.',
+                        logs: errInfo?.logText ?? '',
+                    })
+                }
             })
             .finally(() => {
                 store.trackUploadEnd()
@@ -640,6 +760,8 @@ export function useReportState(schema) {
         if (!photo || photo.uploadStatus !== 'failed') return
 
         photo.uploadStatus = 'uploading'
+        photo.errorCode = null
+        photo.errorMessage = ''
         store.trackUploadStart()
 
         try {
@@ -662,6 +784,7 @@ export function useReportState(schema) {
             // Surface a clear error status rather than hanging.
             photo.uploadStatus = 'failed'
             photo.retryNote    = 'Please remove and re-add this photo.'
+            photo.retryable    = false
         } finally {
             store.trackUploadEnd()
         }
@@ -689,21 +812,40 @@ export function useReportState(schema) {
             thumbUrl:     previewUrl,
             url:          null,
             storagePath:  null,
+            errorCode:    null,
+            errorMessage: '',
+            retryable:    true,
             uploadStatus: 'uploading',
         })
 
         store.marketingPhotos[slotKey].push(photo)
         store.trackUploadStart()
 
-        uploadPhotoToStorage(file, `marketing/${slotKey}`)
+        uploadPhotoToStorage(file, `marketing/${slotKey}`, { slotKey })
             .then(({ url, storagePath }) => {
                 photo.url          = url
                 photo.thumbUrl     = url
                 photo.storagePath  = storagePath
+                photo.errorCode    = null
+                photo.errorMessage = ''
+                photo.retryable    = true
                 photo.uploadStatus = 'done'
             })
-            .catch(() => {
+            .catch((errInfo) => {
+                photo.errorCode    = errInfo?.code ?? 'unknown'
+                photo.errorMessage = errInfo?.message ?? 'Upload failed'
+                photo.retryable    = errInfo?.retryable !== false
                 photo.uploadStatus = 'failed'
+                if (import.meta.env.DEV) {
+                    console.warn('[everhomes] marketing photo upload failed', errInfo)
+                }
+                if (photo.retryable === false) {
+                    openFatalError({
+                        title: 'Upload Error',
+                        message: 'Oops, something went wrong while uploading this photo.',
+                        logs: errInfo?.logText ?? '',
+                    })
+                }
             })
             .finally(() => {
                 store.trackUploadEnd()
@@ -836,6 +978,9 @@ export function useReportState(schema) {
 
         // Online state
         isOnline,
+        fatalError,
+        openFatalError,
+        closeFatalError,
 
         // Setup
         setupErrors,

--- a/src/features/everhomes/views/tools/ReportPage.vue
+++ b/src/features/everhomes/views/tools/ReportPage.vue
@@ -96,6 +96,13 @@
       @submitted="onSubmitted"
     />
 
+    <ErrorLogModal
+      :open="reportState.fatalError.open"
+      :message="reportState.fatalError.message"
+      :logs="reportState.fatalError.logs"
+      @close="reportState.closeFatalError()"
+    />
+
     <!-- ── Clear confirm ────────────────────────────────────────────── -->
     <Teleport to="body">
       <Transition
@@ -144,6 +151,7 @@ import ReportSetup         from '@/features/everhomes/components/ReportSetup.vue
 import SectionAccordion    from '@/features/everhomes/components/SectionAccordion.vue'
 import MarketingPhotoPanel from '@/features/everhomes/components/MarketingPhotoPanel.vue'
 import SubmitModal         from '@/features/everhomes/components/SubmitModal.vue'
+import ErrorLogModal       from '@/features/everhomes/components/ErrorLogModal.vue'
 
 import { useReportState }  from '@/features/everhomes/composables/useReportState'
 


### PR DESCRIPTION
### Motivation
- Surface and capture actionable upload failures (codes/messages) so non-retryable errors can be surfaced to the user and support team.  
- Improve retry behavior and avoid dangling uploads when original `File` data is lost.  
- Preserve checklist data when room instance IDs change by migrating legacy section entries to stable IDs.  

### Description
- Add `ErrorLogModal.vue` and integrate it into `ReportPage.vue` to display fatal upload errors with copyable logs.  
- Implement `fatalError` state and `openFatalError`/`closeFatalError` in `useReportState.js`, and wire fatal error reporting from photo upload failures.  
- Replace naive upload error handling with `classifyUploadError` which captures `code`, `message`, retryability, contextual metadata, and formatted `logText`; propagate that info to photo objects (`errorCode`, `errorMessage`, `retryable`).  
- Update UI and behavior: `ChecklistSection.vue` now shows the error message and code, and only displays the "Tap to Retry" button when `photo.retryable !== false`.  
- Improve retry/restore logic: mark photos non-retryable when original `File` is unavailable and surface an explicit `retryNote`, and open fatal error modal for unrecoverable storage errors.  
- Migrate dynamic room/ensuite section IDs to stable IDs based on `room.id` (e.g. `room_{id}`, `ensuite_{id}`) and add `migrateLegacySectionData` to copy legacy entries (e.g. `bedroom_1`) into the new keys.  
- Small change in `ReportSetup.vue` to pass a `key` when toggling OOA so room metadata stays consistent.  

### Testing
- Ran the project's automated test suite via `npm test` and the linter via `npm run lint`, and both completed successfully.  
- Performed a development build via `npm run build` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69defde025a0832eb6d65a99afb4787b)